### PR TITLE
Fix static asset loading

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,11 +56,29 @@ function decodeMessage(buffer) {
 }
 
 const server = http.createServer((req, res) => {
-  if (req.url === '/') {
-    const html = fs.readFileSync(path.join(__dirname, 'public', 'index.html'));
-    res.writeHead(200, { 'Content-Type': 'text/html' });
-    res.end(html);
-  }
+  const reqPath = req.url === '/' ? '/index.html' : decodeURIComponent(req.url);
+  const filePath = path.join(__dirname, 'public', reqPath);
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const types = {
+      '.html': 'text/html',
+      '.js': 'text/javascript',
+      '.css': 'text/css',
+      '.svg': 'image/svg+xml',
+      '.ico': 'image/x-icon'
+    };
+
+    const contentType = types[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
 });
 
 server.on('upgrade', (req, socket) => {


### PR DESCRIPTION
## Summary
- serve files from the `public` directory so images and other assets load

## Testing
- `curl -I http://localhost:3000/parrot.svg`

------
https://chatgpt.com/codex/tasks/task_b_687e451cb878832fa26af8ce218e5ac4