### PR TITLE
Add random delay to WebSocket replies

### DIFF
--- a/server.js
+++ b/server.js
@@ -104,7 +104,10 @@ server.on('upgrade', (req, socket) => {
     const message = decodeMessage(buffer);
     if (!message) return;
     const reply = `PARROT: "${message}"`;
-    socket.write(encodeMessage(reply));
+    const delay = Math.random() * 2000;
+    setTimeout(() => {
+      socket.write(encodeMessage(reply));
+    }, delay);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a random delay between 0 and 2 seconds for each WebSocket message reply

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` (started server and displayed `Server running at http://localhost:3000`)

------
https://chatgpt.com/codex/tasks/task_b_687f6514476c832f970ef64862d86e44