### PR TITLE
Add Docker Compose and ngrok for remote testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+docker-compose.yml
+.git
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and set your ngrok auth token
+NGROK_AUTHTOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Node Modules
-node_modules/
+node_modules
+
+# Environment variables
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ To gracefully end a session, send the message `close` and the server will close 
 ## Running a Load Test
 
 To simulate thousands of concurrent connections, use [Gatling](https://gatling.io/) or a similar load testing tool. Point the WebSocket scenario at `ws://localhost:3000` and configure the desired number of virtual users. There is a companion sample load test available [WebSockets JS load test](https://github.com/stb13579/WebSocketTestJS).
+
+## Docker and ngrok
+
+This repository includes a `Dockerfile` and `docker-compose.yml` to expose the server through [ngrok](https://ngrok.com) for remote load testing.
+
+1. Create an ngrok account and obtain an auth token.
+2. Copy `.env.example` to `.env` and add your token: `NGROK_AUTHTOKEN=<token>`.
+3. Start the stack:
+
+```bash
+docker compose up --build
+```
+
+The ngrok service will print a forwarding URL such as `https://XXXX.ngrok-free.app`. Use this URL in your remote load testing tool to target the WebSocket server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+  ngrok:
+    image: ngrok/ngrok:latest
+    command: http app:3000
+    env_file:
+      - .env
+    depends_on:
+      - app


### PR DESCRIPTION
## Summary
- containerize app with Dockerfile and .dockerignore
- compose Node app with ngrok tunnel for external access
- document ngrok/Docker usage in README
- load ngrok token from `.env` and provide example file, ignoring it from git and Docker builds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `docker-compose config` *(fails: command not found: docker-compose)*
- `docker-compose build` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_b_689b3a21d258832fa1a1f593e1e72d4e