### PR TITLE
Fix docker-compose ngrok exposure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,21 @@
 version: "3.9"
+
 services:
   app:
     build:
-      context: .                         # Build context is the root of the repo
-      dockerfile: /Dockerfile  # Explicit Dockerfile p
+      context: .
+      dockerfile: Dockerfile
     ports:
       - "3000:3000"
+
   ngrok:
     image: ngrok/ngrok:latest
-    command: http app:3000
+    command:
+      - http
+      - app:3000
     environment:
-      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN:?NGROK_AUTHTOKEN must be set}
     depends_on:
       - app
+    ports:
+      - "4040:4040"


### PR DESCRIPTION
## Summary
- correct the Dockerfile path used by the app service build
- configure the ngrok service to forward traffic to the app container and expose the inspector
- ensure the ngrok authtoken must be provided via environment variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cbb5f399b0832faf121106f63cc6d7