### PR TITLE
Simplify Gatling runtime configuration

### DIFF
--- a/gatling/js/src/basicSimulation.gatling.js
+++ b/gatling/js/src/basicSimulation.gatling.js
@@ -1,39 +1,72 @@
-import { simulation, constantUsersPerSec, scenario, feed, pause, exec, repeat, regex, csv } from "@gatling.io/core";
+import {
+  simulation,
+  constantUsersPerSec,
+  scenario,
+  feed,
+  pause,
+  exec,
+  repeat,
+  regex,
+  csv,
+  getParameter,
+} from "@gatling.io/core";
 import { http, ws } from "@gatling.io/http";
 
-export default simulation((setUp) => {
+const toNumber = (value, fallback) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
 
-  const BASE_URL = getParameter("baseUrl", "http://localhost:3000");
-  const questionsFeeder = csv("resources/health_insurance_chatbot_questions.csv").random(); // Load the CSV file with questions
+const deriveWebSocketUrl = (httpUrl, fallback) => {
+  try {
+    const url = new URL(httpUrl);
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    return url.toString();
+  } catch {
+    return fallback;
+  }
+};
+
+export default simulation((setUp) => {
+  const baseUrl = getParameter("baseUrl", "http://localhost:3000");
+  const wsBaseUrl = getParameter(
+    "wsBaseUrl",
+    deriveWebSocketUrl(baseUrl, "ws://localhost:3000"),
+  );
+  const usersPerSec = toNumber(getParameter("usersPerSec", "2"), 2);
+  const durationSeconds = toNumber(getParameter("durationSeconds", "15"), 15);
+
+  const questionsFeeder = csv("resources/health_insurance_chatbot_questions.csv").random();
 
   const httpProtocol = http
-  .baseUrl(BASE_URL)
-  .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-  .doNotTrackHeader("1")
-  .acceptLanguageHeader("en-US,en;q=0.5")
-  .acceptEncodingHeader("gzip, deflate")
-  .userAgentHeader("Gatling2")
-  .wsBaseUrl("ws://localhost:3000");
+    .baseUrl(baseUrl)
+    .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+    .doNotTrackHeader("1")
+    .acceptLanguageHeader("en-US,en;q=0.5")
+    .acceptEncodingHeader("gzip, deflate")
+    .userAgentHeader("Gatling2")
+    .wsBaseUrl(wsBaseUrl);
 
-const scn = scenario("WebSocket")
-  .exec(
-    http("Home").get("/"),
-    pause(1),
-    exec(session => session.set("id", "Gatling" + session.userId())), // Set a unique ID for the session
-    ws("Connect WS").connect("/"),
-    pause(1),
-    repeat(5, "i").on(
-      feed(questionsFeeder), // Feed data from CSV before each message exchange
-      ws("Customer Question") // Send the question and wait for response
-        .sendText(session => session.get("user_question")) // Use data from the feeder to send the question
-        .await(30).on(
-          ws.checkTextMessage("Chatbot Response").check(regex("(.*)")), // Check for a response from the chatbot
-        )
-    ),
-    pause(1),
-    ws("Close WS").close()
-  );
+  const scn = scenario("WebSocket")
+    .exec(
+      http("Home").get("/"),
+      pause(1),
+      exec((session) => session.set("id", "Gatling" + session.userId())),
+      ws("Connect WS").connect("/"),
+      pause(1),
+      repeat(5, "i").on(
+        feed(questionsFeeder),
+        ws("Customer Question")
+          .sendText((session) => session.get("user_question"))
+          .await(30).on(
+            ws.checkTextMessage("Chatbot Response").check(regex("(.*)")),
+          ),
+      ),
+      pause(1),
+      ws("Close WS").close(),
+    );
+
   setUp(
-    scn.injectOpen(constantUsersPerSec(2).during(15))
+    scn.injectOpen(constantUsersPerSec(usersPerSec).during(durationSeconds)),
   ).protocols(httpProtocol);
 });

--- a/gatling/typescript/src/basicSimulation.gatling.ts
+++ b/gatling/typescript/src/basicSimulation.gatling.ts
@@ -1,32 +1,36 @@
-import { simulation, scenario, atOnceUsers, global, getParameter } from "@gatling.io/core";
+import {
+  simulation,
+  scenario,
+  constantUsersPerSec,
+  global,
+  getParameter,
+} from "@gatling.io/core";
 import { http } from "@gatling.io/http";
 
-export default simulation((setUp) => {
-  // Load VU count from system properties
-  // Reference: https://docs.gatling.io/guides/passing-parameters/
-  const vu = parseInt(getParameter("vu", "1"));
+const toNumber = (value: string, fallback: number): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
 
-  // Define HTTP configuration
-  // Reference: https://docs.gatling.io/reference/script/protocols/http/protocol/
+export default simulation((setUp) => {
+  const baseUrl = getParameter("baseUrl", "https://api-ecomm.gatling.io");
+  const usersPerSec = toNumber(getParameter("usersPerSec", "1"), 1);
+  const durationSeconds = toNumber(getParameter("durationSeconds", "1"), 1);
+
   const httpProtocol = http
-    .baseUrl("https://api-ecomm.gatling.io")
+    .baseUrl(baseUrl)
     .acceptHeader("application/json")
     .userAgentHeader(
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
-
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
     );
 
-  // Define scenario
-  // Reference: https://docs.gatling.io/reference/script/core/scenario/
   const scn = scenario("Scenario").exec(http("Session").get("/session"));
 
-  // Define assertions
-  // Reference: https://docs.gatling.io/reference/script/core/assertions/
   const assertion = global().failedRequests().count().lt(1.0);
 
-  // Define injection profile and execute the test
-  // Reference: https://docs.gatling.io/reference/script/core/injection/
-  setUp(scn.injectOpen(atOnceUsers(vu)))
+  setUp(
+    scn.injectOpen(constantUsersPerSec(usersPerSec).during(durationSeconds)),
+  )
     .assertions(assertion)
     .protocols(httpProtocol);
 });


### PR DESCRIPTION
## Summary
- keep the Gatling base and WebSocket URLs configurable via getParameter defaults without environment variable fallbacks
- parameterize the constant users-per-second and duration injection profile settings in both the JavaScript and TypeScript simulations while reverting other scenario settings to static defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cbba0f9eb8832fbdaef29ba3b49eb7