### PR TITLE
Randomize Gatling question count

### DIFF
--- a/gatling/js/src/basicSimulation.gatling.js
+++ b/gatling/js/src/basicSimulation.gatling.js
@@ -114,14 +114,23 @@ export default simulation((setUp) => {
       ws("Connect WS").connect("/"),
       /**
        * Pauses for 1 second.
-       */
+      */
       pause(1),
+      /**
+       * Determines a random number of customer questions for this session.
+       *
+       * @param {Session} session - The Gatling session object.
+       * @returns {Session} The updated session with a random question count.
+       */
+      exec((session) =>
+        session.set("maxQuestions", Math.floor(Math.random() * 10) + 1),
+      ),
       /**
        * Repeats sending customer questions and awaiting chatbot responses.
        *
        * @param {number} i - The iteration index.
        */
-      repeat(5, "i").on(
+      repeat((session) => session.get("maxQuestions"), "i").on(
         feed(questionsFeeder),
         /**
          * Sends a user question over WebSocket and awaits a response.


### PR DESCRIPTION
## Summary
- assign a random number of chatbot questions to each virtual user session in the Gatling simulation
- update the repeat loop to use the session-specific question count so interactions vary between 1 and 10

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cbf636e828832fb4ed83f6e2a25154